### PR TITLE
ci: add registry-mode post-publish CMS smoke tests

### DIFF
--- a/.github/workflows/post-publish-registry-smoke.yml
+++ b/.github/workflows/post-publish-registry-smoke.yml
@@ -1,0 +1,169 @@
+name: Post-Publish Registry Smoke
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published package version without leading v (for example 0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    strategy:
+      fail-fast: false
+      matrix:
+        cms: [hugo, astro, docusaurus, mkdocs, eleventy, jekyll]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ github.event.inputs.version }}"
+          fi
+
+          if [[ -z "$VERSION" ]]; then
+            echo "Unable to resolve package version." >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for published package availability
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          wait_for_npm() {
+            local pkg="$1"
+            local tries=50
+            for i in $(seq 1 "$tries"); do
+              local found
+              found="$(timeout 20s npm view "${pkg}@${VERSION}" version 2>/dev/null || true)"
+              if [[ "$found" == "$VERSION" ]]; then
+                echo "Found npm package ${pkg}@${VERSION}"
+                return 0
+              fi
+              sleep 6
+            done
+            echo "Timed out waiting for npm package ${pkg}@${VERSION}" >&2
+            return 1
+          }
+
+          wait_for_pypi() {
+            local pkg="$1"
+            local tries=50
+            for i in $(seq 1 "$tries"); do
+              local found
+              found="$(curl -fsS "https://pypi.org/pypi/${pkg}/json" 2>/dev/null | jq -r '.info.version' || true)"
+              if [[ "$found" == "$VERSION" ]]; then
+                echo "Found PyPI package ${pkg}==${VERSION}"
+                return 0
+              fi
+              sleep 6
+            done
+            echo "Timed out waiting for PyPI package ${pkg}==${VERSION}" >&2
+            return 1
+          }
+
+          wait_for_rubygems() {
+            local pkg="$1"
+            local tries=50
+            for i in $(seq 1 "$tries"); do
+              local found
+              found="$(curl -fsS "https://rubygems.org/api/v1/gems/${pkg}.json" 2>/dev/null | jq -r '.version' || true)"
+              if [[ "$found" == "$VERSION" ]]; then
+                echo "Found RubyGem ${pkg}-${VERSION}"
+                return 0
+              fi
+              sleep 6
+            done
+            echo "Timed out waiting for RubyGem ${pkg}-${VERSION}" >&2
+            return 1
+          }
+
+          case "${{ matrix.cms }}" in
+            hugo)
+              wait_for_npm "@jt55401/eddie-hugo"
+              ;;
+            astro)
+              wait_for_npm "@jt55401/eddie-astro"
+              ;;
+            docusaurus)
+              wait_for_npm "@jt55401/eddie-docusaurus"
+              ;;
+            eleventy)
+              wait_for_npm "@jt55401/eddie-eleventy"
+              ;;
+            mkdocs)
+              wait_for_pypi "eddie-mkdocs"
+              ;;
+            jekyll)
+              wait_for_rubygems "eddie-jekyll"
+              ;;
+            *)
+              echo "Unsupported CMS matrix value: ${{ matrix.cms }}" >&2
+              exit 2
+              ;;
+          esac
+
+      - name: Download release runtime assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+
+          download_asset() {
+            local pattern="$1"
+            local tries=40
+            for i in $(seq 1 "$tries"); do
+              if gh release download "$TAG" --repo jt55401/eddie --pattern "$pattern" --dir dist --clobber >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep 6
+            done
+            echo "Timed out downloading asset $pattern from release $TAG" >&2
+            return 1
+          }
+
+          download_asset "eddie.wasm"
+          download_asset "eddie-wasm.js"
+          download_asset "eddie-worker.js"
+          download_asset "eddie-widget.js"
+
+      - name: Build CMS E2E image
+        run: |
+          set -euo pipefail
+          docker build \
+            -f "integrations/${{ matrix.cms }}/tests/docker/Dockerfile" \
+            -t "eddie-${{ matrix.cms }}-registry-smoke" \
+            .
+
+      - name: Run registry smoke E2E
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD:/repo" \
+            -e EDDIE_INSTALL_SOURCE=registry \
+            -e EDDIE_PACKAGE_VERSION="$VERSION" \
+            "eddie-${{ matrix.cms }}-registry-smoke"

--- a/docs/guides/github-actions.md
+++ b/docs/guides/github-actions.md
@@ -1,6 +1,6 @@
 # GitHub Actions Guide
 
-This repository ships six workflows:
+This repository ships seven workflows:
 
 - `ci.yml`: runs Rust tests and verifies widget build output on pushes and pull requests.
 - `release.yml`: builds release artifacts for Eddie and publishes them on `v*` tags.
@@ -8,6 +8,7 @@ This repository ships six workflows:
 - `publish-npm.yml`: publishes npm packages with trusted publishing (OIDC).
 - `publish-pypi.yml`: publishes PyPI packages with trusted publishing (OIDC).
 - `publish-rubygems.yml`: publishes gems with trusted publishing (OIDC).
+- `post-publish-registry-smoke.yml`: runs CMS Docker E2E in `registry` mode against published packages and release assets.
 
 See also: [Package Publishing Guide](package-publishing.md) for setup details.
 

--- a/docs/guides/package-publishing.md
+++ b/docs/guides/package-publishing.md
@@ -5,6 +5,7 @@ This repo now includes OIDC-first release workflows:
 - `.github/workflows/publish-npm.yml`
 - `.github/workflows/publish-pypi.yml`
 - `.github/workflows/publish-rubygems.yml`
+- `.github/workflows/post-publish-registry-smoke.yml`
 
 All three workflows read publish targets from `.github/publish-packages.json`.
 
@@ -87,6 +88,8 @@ Push a tag (example: `v0.3.0`).
 
 All three publish workflows trigger on `v*` tags and publish targets from `.github/publish-packages.json`.
 
+After publish, `post-publish-registry-smoke.yml` runs CMS Docker E2E against registry packages + release runtime assets to verify install, indexing, and CLI search all succeed.
+
 ### Manual publish / dry-run
 
 Run each workflow with `workflow_dispatch`.
@@ -98,6 +101,11 @@ Optional input:
   - npm: runs `npm publish --dry-run`
   - PyPI: builds and runs `twine check`, skips upload
   - RubyGems: builds gem, skips `gem push`
+
+For registry smoke tests:
+
+- run `post-publish-registry-smoke.yml` with input `version` (for example `0.2.0`)
+- or rely on automatic trigger from tag pushes (`v*`)
 
 ## Secrets
 

--- a/integrations/astro/tests/docker/run-e2e.sh
+++ b/integrations/astro/tests/docker/run-e2e.sh
@@ -4,6 +4,43 @@ set -euo pipefail
 REPO_ROOT="/repo"
 WORKDIR="/tmp/astro-e2e"
 SITE_ROOT="$WORKDIR/site"
+INSTALL_SOURCE="${EDDIE_INSTALL_SOURCE:-local}"
+PACKAGE_VERSION="${EDDIE_PACKAGE_VERSION:-}"
+
+npm_package_spec() {
+  local package_name="$1"
+  if [[ -n "$PACKAGE_VERSION" ]]; then
+    printf "%s@%s" "$package_name" "$PACKAGE_VERSION"
+  else
+    printf "%s" "$package_name"
+  fi
+}
+
+install_eddie_astro() {
+  case "$INSTALL_SOURCE" in
+    local)
+      bash "$REPO_ROOT/integrations/astro/plugin/install.sh" "$SITE_ROOT"
+      ;;
+    registry)
+      npx -y "$(npm_package_spec "@jt55401/eddie-astro")" "$SITE_ROOT" "$REPO_ROOT/dist"
+      ;;
+    *)
+      echo "Unsupported EDDIE_INSTALL_SOURCE: $INSTALL_SOURCE" >&2
+      exit 2
+      ;;
+  esac
+}
+
+verify_index_and_search() {
+  local index_path="$1"
+  local output
+  output="$("$REPO_ROOT/target/release/eddie" search \
+    --index "$index_path" \
+    --query "Revelance" \
+    --mode keyword \
+    --top-k 10 2>&1)"
+  echo "$output" | grep -qi "Queue Before Coffee"
+}
 
 rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
@@ -19,7 +56,7 @@ cd "$SITE_ROOT"
 npm install
 
 echo "==> Integrating Eddie Astro plugin"
-bash "$REPO_ROOT/integrations/astro/plugin/install.sh" "$SITE_ROOT"
+install_eddie_astro
 
 echo "==> Building Eddie binary"
 cd "$REPO_ROOT"
@@ -34,6 +71,7 @@ fi
   --cms astro \
   --content-dir "$CONTENT_DIR" \
   --output "$SITE_ROOT/public/eddie/index.ed"
+verify_index_and_search "$SITE_ROOT/public/eddie/index.ed"
 
 echo "==> Starting Astro dev server"
 cd "$SITE_ROOT"

--- a/integrations/docusaurus/tests/docker/run-e2e.sh
+++ b/integrations/docusaurus/tests/docker/run-e2e.sh
@@ -4,6 +4,43 @@ set -euo pipefail
 REPO_ROOT="/repo"
 WORKDIR="/tmp/docusaurus-e2e"
 SITE_ROOT="$WORKDIR/site"
+INSTALL_SOURCE="${EDDIE_INSTALL_SOURCE:-local}"
+PACKAGE_VERSION="${EDDIE_PACKAGE_VERSION:-}"
+
+npm_package_spec() {
+  local package_name="$1"
+  if [[ -n "$PACKAGE_VERSION" ]]; then
+    printf "%s@%s" "$package_name" "$PACKAGE_VERSION"
+  else
+    printf "%s" "$package_name"
+  fi
+}
+
+install_eddie_docusaurus() {
+  case "$INSTALL_SOURCE" in
+    local)
+      bash "$REPO_ROOT/integrations/docusaurus/plugin/install.sh" "$SITE_ROOT"
+      ;;
+    registry)
+      npx -y "$(npm_package_spec "@jt55401/eddie-docusaurus")" "$SITE_ROOT" "$REPO_ROOT/dist"
+      ;;
+    *)
+      echo "Unsupported EDDIE_INSTALL_SOURCE: $INSTALL_SOURCE" >&2
+      exit 2
+      ;;
+  esac
+}
+
+verify_index_and_search() {
+  local index_path="$1"
+  local output
+  output="$("$REPO_ROOT/target/release/eddie" search \
+    --index "$index_path" \
+    --query "Revelance" \
+    --mode keyword \
+    --top-k 10 2>&1)"
+  echo "$output" | grep -qi "Queue Before Coffee"
+}
 
 rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
@@ -19,7 +56,7 @@ cd "$SITE_ROOT"
 npm install
 
 echo "==> Integrating Eddie Docusaurus plugin"
-bash "$REPO_ROOT/integrations/docusaurus/plugin/install.sh" "$SITE_ROOT"
+install_eddie_docusaurus
 
 echo "==> Building Eddie binary"
 cd "$REPO_ROOT"
@@ -30,6 +67,7 @@ echo "==> Indexing Docusaurus docs"
   --cms docusaurus \
   --content-dir "$SITE_ROOT/docs" \
   --output "$SITE_ROOT/static/eddie/index.ed"
+verify_index_and_search "$SITE_ROOT/static/eddie/index.ed"
 
 echo "==> Building Docusaurus site"
 cd "$SITE_ROOT"

--- a/integrations/eleventy/tests/docker/run-e2e.sh
+++ b/integrations/eleventy/tests/docker/run-e2e.sh
@@ -4,6 +4,43 @@ set -euo pipefail
 REPO_ROOT="/repo"
 WORKDIR="/tmp/eleventy-e2e"
 SITE_ROOT="$WORKDIR/site"
+INSTALL_SOURCE="${EDDIE_INSTALL_SOURCE:-local}"
+PACKAGE_VERSION="${EDDIE_PACKAGE_VERSION:-}"
+
+npm_package_spec() {
+  local package_name="$1"
+  if [[ -n "$PACKAGE_VERSION" ]]; then
+    printf "%s@%s" "$package_name" "$PACKAGE_VERSION"
+  else
+    printf "%s" "$package_name"
+  fi
+}
+
+install_eddie_eleventy() {
+  case "$INSTALL_SOURCE" in
+    local)
+      bash "$REPO_ROOT/integrations/eleventy/plugin/install.sh" "$SITE_ROOT"
+      ;;
+    registry)
+      npx -y "$(npm_package_spec "@jt55401/eddie-eleventy")" "$SITE_ROOT" "$REPO_ROOT/dist"
+      ;;
+    *)
+      echo "Unsupported EDDIE_INSTALL_SOURCE: $INSTALL_SOURCE" >&2
+      exit 2
+      ;;
+  esac
+}
+
+verify_index_and_search() {
+  local index_path="$1"
+  local output
+  output="$("$REPO_ROOT/target/release/eddie" search \
+    --index "$index_path" \
+    --query "Revelance" \
+    --mode keyword \
+    --top-k 10 2>&1)"
+  echo "$output" | grep -qi "Queue Before Coffee"
+}
 
 rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
@@ -19,7 +56,7 @@ cd "$SITE_ROOT"
 npm install
 
 echo "==> Integrating Eddie Eleventy plugin"
-bash "$REPO_ROOT/integrations/eleventy/plugin/install.sh" "$SITE_ROOT"
+install_eddie_eleventy
 
 echo "==> Building Eddie binary"
 cd "$REPO_ROOT"
@@ -30,6 +67,7 @@ echo "==> Indexing Eleventy content"
   --cms eleventy \
   --content-dir "$SITE_ROOT/src" \
   --output "$SITE_ROOT/public/eddie/index.ed"
+verify_index_and_search "$SITE_ROOT/public/eddie/index.ed"
 
 echo "==> Building Eleventy site"
 cd "$SITE_ROOT"

--- a/integrations/hugo/tests/docker/Dockerfile
+++ b/integrations/hugo/tests/docker/Dockerfile
@@ -4,6 +4,11 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends git curl ca-certificates python3 perl \
  && rm -rf /var/lib/apt/lists/*
 
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
 RUN HUGO_VERSION=0.126.1 \
  && curl -fsSL -o /tmp/hugo.tar.gz "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" \
  && tar -xzf /tmp/hugo.tar.gz -C /usr/local/bin hugo \

--- a/integrations/hugo/tests/docker/run-e2e.sh
+++ b/integrations/hugo/tests/docker/run-e2e.sh
@@ -4,6 +4,43 @@ set -euo pipefail
 REPO_ROOT="/repo"
 WORKDIR="/tmp/hugo-e2e"
 SITE_ROOT="$WORKDIR/site"
+INSTALL_SOURCE="${EDDIE_INSTALL_SOURCE:-local}"
+PACKAGE_VERSION="${EDDIE_PACKAGE_VERSION:-}"
+
+npm_package_spec() {
+  local package_name="$1"
+  if [[ -n "$PACKAGE_VERSION" ]]; then
+    printf "%s@%s" "$package_name" "$PACKAGE_VERSION"
+  else
+    printf "%s" "$package_name"
+  fi
+}
+
+install_eddie_hugo() {
+  case "$INSTALL_SOURCE" in
+    local)
+      bash "$REPO_ROOT/integrations/hugo/plugin/install.sh" "$SITE_ROOT"
+      ;;
+    registry)
+      npx -y "$(npm_package_spec "@jt55401/eddie-hugo")" "$SITE_ROOT" "$REPO_ROOT/dist"
+      ;;
+    *)
+      echo "Unsupported EDDIE_INSTALL_SOURCE: $INSTALL_SOURCE" >&2
+      exit 2
+      ;;
+  esac
+}
+
+verify_index_and_search() {
+  local index_path="$1"
+  local output
+  output="$("$REPO_ROOT/target/release/eddie" search \
+    --index "$index_path" \
+    --query "Revelance" \
+    --mode keyword \
+    --top-k 10 2>&1)"
+  echo "$output" | grep -qi "Queue Before Coffee"
+}
 
 rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
@@ -24,7 +61,7 @@ echo "==> Seeding Eddie voice content corpus"
 bash "$REPO_ROOT/integrations/hugo/tests/docker/seed-content.sh" "$SITE_ROOT"
 
 echo "==> Integrating Eddie Hugo plugin"
-bash "$REPO_ROOT/integrations/hugo/plugin/install.sh" "$SITE_ROOT"
+install_eddie_hugo
 
 echo "==> Building Eddie binary"
 cd "$REPO_ROOT"
@@ -35,6 +72,7 @@ echo "==> Indexing Hugo content"
   --cms hugo \
   --content-dir "$SITE_ROOT/content" \
   --output "$SITE_ROOT/static/eddie/index.ed"
+verify_index_and_search "$SITE_ROOT/static/eddie/index.ed"
 
 echo "==> Building Hugo site"
 cd "$SITE_ROOT"

--- a/integrations/jekyll/tests/docker/run-e2e.sh
+++ b/integrations/jekyll/tests/docker/run-e2e.sh
@@ -4,6 +4,39 @@ set -euo pipefail
 REPO_ROOT="/repo"
 WORKDIR="/tmp/jekyll-e2e"
 SITE_ROOT="$WORKDIR/site"
+INSTALL_SOURCE="${EDDIE_INSTALL_SOURCE:-local}"
+PACKAGE_VERSION="${EDDIE_PACKAGE_VERSION:-}"
+
+install_eddie_jekyll() {
+  case "$INSTALL_SOURCE" in
+    local)
+      bash "$REPO_ROOT/integrations/jekyll/plugin/install.sh" "$SITE_ROOT"
+      ;;
+    registry)
+      if [[ -n "$PACKAGE_VERSION" ]]; then
+        gem install eddie-jekyll -v "$PACKAGE_VERSION" --no-document
+      else
+        gem install eddie-jekyll --no-document
+      fi
+      eddie-jekyll-install "$SITE_ROOT" "$REPO_ROOT/dist"
+      ;;
+    *)
+      echo "Unsupported EDDIE_INSTALL_SOURCE: $INSTALL_SOURCE" >&2
+      exit 2
+      ;;
+  esac
+}
+
+verify_index_and_search() {
+  local index_path="$1"
+  local output
+  output="$("$REPO_ROOT/target/release/eddie" search \
+    --index "$index_path" \
+    --query "Revelance" \
+    --mode keyword \
+    --top-k 10 2>&1)"
+  echo "$output" | grep -qi "Queue Before Coffee"
+}
 
 rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
@@ -19,7 +52,7 @@ cd "$SITE_ROOT"
 bundle install
 
 echo "==> Integrating Eddie Jekyll plugin"
-bash "$REPO_ROOT/integrations/jekyll/plugin/install.sh" "$SITE_ROOT"
+install_eddie_jekyll
 
 echo "==> Building Eddie binary"
 cd "$REPO_ROOT"
@@ -30,6 +63,7 @@ echo "==> Indexing Jekyll content"
   --cms jekyll \
   --content-dir "$SITE_ROOT" \
   --output "$SITE_ROOT/assets/eddie/index.ed"
+verify_index_and_search "$SITE_ROOT/assets/eddie/index.ed"
 
 echo "==> Building Jekyll site"
 cd "$SITE_ROOT"

--- a/integrations/mkdocs/tests/docker/run-e2e.sh
+++ b/integrations/mkdocs/tests/docker/run-e2e.sh
@@ -4,6 +4,39 @@ set -euo pipefail
 REPO_ROOT="/repo"
 WORKDIR="/tmp/mkdocs-e2e"
 SITE_ROOT="$WORKDIR/site"
+INSTALL_SOURCE="${EDDIE_INSTALL_SOURCE:-local}"
+PACKAGE_VERSION="${EDDIE_PACKAGE_VERSION:-}"
+
+install_eddie_mkdocs() {
+  case "$INSTALL_SOURCE" in
+    local)
+      bash "$REPO_ROOT/integrations/mkdocs/plugin/install.sh" "$SITE_ROOT"
+      ;;
+    registry)
+      local spec="eddie-mkdocs"
+      if [[ -n "$PACKAGE_VERSION" ]]; then
+        spec="${spec}==${PACKAGE_VERSION}"
+      fi
+      pip3 install --break-system-packages --no-cache-dir "$spec"
+      eddie-mkdocs-install "$SITE_ROOT" "$REPO_ROOT/dist"
+      ;;
+    *)
+      echo "Unsupported EDDIE_INSTALL_SOURCE: $INSTALL_SOURCE" >&2
+      exit 2
+      ;;
+  esac
+}
+
+verify_index_and_search() {
+  local index_path="$1"
+  local output
+  output="$("$REPO_ROOT/target/release/eddie" search \
+    --index "$index_path" \
+    --query "Revelance" \
+    --mode keyword \
+    --top-k 10 2>&1)"
+  echo "$output" | grep -qi "Queue Before Coffee"
+}
 
 rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
@@ -21,7 +54,7 @@ fi
 pip3 install --break-system-packages --no-cache-dir mkdocs mkdocs-material mkdocs-minify-plugin
 
 echo "==> Integrating Eddie MkDocs plugin"
-bash "$REPO_ROOT/integrations/mkdocs/plugin/install.sh" "$SITE_ROOT"
+install_eddie_mkdocs
 
 echo "==> Building Eddie binary"
 cd "$REPO_ROOT"
@@ -32,6 +65,7 @@ echo "==> Indexing MkDocs docs"
   --cms mkdocs \
   --content-dir "$SITE_ROOT/docs" \
   --output "$SITE_ROOT/docs/eddie/index.ed"
+verify_index_and_search "$SITE_ROOT/docs/eddie/index.ed"
 
 echo "==> Building MkDocs site"
 cd "$SITE_ROOT"


### PR DESCRIPTION
## Summary
- add a post-publish registry smoke workflow for all CMS integrations
- extend CMS docker E2E scripts with `EDDIE_INSTALL_SOURCE=registry` support
- in registry mode, install integration packages from npm/PyPI/RubyGems
- add a CLI search assertion after index generation in each CMS E2E
- update docs for workflow inventory and package publishing flow

## Behavior
- existing local script path remains default (`EDDIE_INSTALL_SOURCE=local`)
- new smoke workflow uses published package version and release runtime assets
- matrix runs: hugo, astro, docusaurus, mkdocs, eleventy, jekyll
